### PR TITLE
Add minimal React example

### DIFF
--- a/react-app/README.md
+++ b/react-app/README.md
@@ -1,0 +1,7 @@
+# Simple React App
+
+This directory contains a minimal React application that loads React from a CDN.
+
+## How to run
+
+Open `index.html` in a modern browser. You should see a page displaying **"Hello React!"**.

--- a/react-app/index.html
+++ b/react-app/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Simple React App</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel" src="index.jsx"></script>
+  </body>
+</html>

--- a/react-app/index.jsx
+++ b/react-app/index.jsx
@@ -1,0 +1,5 @@
+function App() {
+  return <h1>Hello React!</h1>;
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary
- add a `react-app` folder containing a very small React application that loads React from a CDN

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d26d69834832fb3991599d2dba162